### PR TITLE
Clarification about the new add-ons field in the bosh manifest struct

### DIFF
--- a/creating.html.md.erb
+++ b/creating.html.md.erb
@@ -476,7 +476,7 @@ For example
 <br>
 <a id="dashboard-url-manifest"></a>**manifest-YAML**
 
-The current manifest as YAML. The format of the manifest should match the [BOSH] v2 manifest](https://bosh.io/docs/manifest-v2.html).
+The current manifest as YAML. The format of the manifest should match the [BOSH v2 manifest](https://bosh.io/docs/manifest-v2.html).
 
 For example
 
@@ -513,6 +513,11 @@ update:
   max_in_flight: 4
 tags:
   product: my-product
+addons:
+- name: some-addon
+  jobs:
+  - name: my-example-server
+    release: my-service
 ```
 
 ---

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -32,7 +32,10 @@ owner: London Services Enablement
 - Expose BOSH error messages to application developers when `expose_bosh_errors`
   flag is enabled in manifest.
 - Bump to Golang 1.10
-- Addons support in the BOSH manifest
+- Exposed the BOSH manifest property
+  [Addons](https://bosh.io/docs/manifest-v2.html#addons) for service authors via
+  the sdk `bosh.BoshManifest.Addons` field. Use this to apply add-ons to
+  on-demand service instances.
 - Added `instance_groups.env` to `service_catalog.plans`. This property accepts
   an arbitrary hash, to support passing through undocumented properties
 - Added support for optional `features` block, which enables BOSH features


### PR DESCRIPTION
Mention usage and point to bosh docs

[#155950614]

Co-authored-by: Kieron Browne <kbrowne@pivotal.io>