### PR TITLE
Add docs for securing manifests

### DIFF
--- a/creating.html.md.erb
+++ b/creating.html.md.erb
@@ -457,17 +457,64 @@ The following table describes the supported exit codes and output for the `gener
 
 | exit code     | Description     | Output                                                                                                                           |
 |:--------------|:----------------|:---------------------------------------------------------------------------------------------------------------------------------|
-| 0             | success         | <ul><li>Stdout: JSON document containing the BOSH manifest YAML</li></ul>                                                                          |
+| 0             | success         | <ul><li>Stdout: JSON document containing the BOSH manifest YAML and a map of adapter generated secrets</li></ul>                 |
 | 10            | not implemented |                                                                                                                                  |
-| anything else | failure         | Stdout: <ul><li>optional error message for CF CLI users</li> <li>Stderr: error message for operator</li> <li>ODB logs both stdout and stderr</li></ul> |
+| anything else | failure         | <ul><li>Stdout: optional error message for CF CLI users</li> <li>Stderr: error message for operator</li> <li>ODB logs both stdout and stderr</li></ul>     |
 
 **Output JSON format**
 
 ```json
 {
-  "manifest": "<generated BOSH manifest, as YAML>"
+  "manifest": "<generated BOSH manifest, as YAML>",
+  "secrets": { "secret1":"value1", "secret2":"value2" }
 }
 ```
+
+#### <a id="odb-managed-secrets"></a>Storing secrets on CredHub
+
+It is possible for the Service Adapter to generate secrets and, instead of
+writing these secrets in plain text in the manifest, to use ODB as a proxy to
+BOSH CredHub Config server. To do so, the adapter should generate the manifest
+with a special notation and output the secret as part of the `secrets` map. For
+example, consider the following `generate-manifest` output:
+
+```json
+{
+  "manifest": "password: ((odb_secret:the_password))",
+  "secrets": {
+    "the_password":"some-random-password"
+  }
+}
+```
+
+During provision, ODB will:
+
+1. Generate a CredHub name for each secret in the
+`secrets` map (for example: `/odb/service-offering-id/instance-id/secret-name`)
+1. Replace all occurrences of `((odb_secret:<secret-name>))` with the generated
+CredHub name
+1. Deploy the updated manifest.
+
+**Persisting credentials on updates**
+
+Similarly when dealing with properties that need to persist across updates,
+service adapter authors should extract the existing value for any ODB managed
+secrets from the previous manifest, when present.
+
+If the previous manifest looks like this:
+
+```
+name: the-deployment
+# ...
+properties:
+password: ((/odb/<service-guid>/<service-instance-guid/the_password))
+```
+
+then `generate-manifest` should not replace `properties.password` with
+`((odb_secret:password))`
+
+For details on how to use the value during bind, check the [create-binding subcommand documentation](#create-binding)
+
 ---
 
 ### <a id="dashboard-url"></a>dashboard-url
@@ -652,7 +699,8 @@ a JSON document using stdin.
     "binding_id": "BINDING-ID",
     "bosh_vms": "BOSH-VMS-JSON",
     "manifest": "MANIFEST-YAML",
-    "request_parameters": "REQUEST-PARAMETERS-JSON"
+    "request_parameters": "REQUEST-PARAMETERS-JSON",
+    "secrets": "MANIFEST-SECRETS-JSON"
   }
 }
 ```
@@ -740,6 +788,41 @@ See the following example:
   "service_id": "my-service"
   }
   ```
+
+**<a id="create-binding-secrets"></a>SECRETS**
+
+When the broker is configured with `resolve_manifest_secrets_at_bind` set to true,
+any secrets in the service instance manifest using references to BOSH generated
+variables or literal CredHub paths will be resolved and provided to the adapter in the secrets
+JSON parameter.
+
+For a service instance manifest like this:
+
+```yaml
+# ...
+password: ((redis_password))
+root_ca: ((/global/root_ca))
+
+variables:
+- name: redis_password
+  type: password
+```
+
+The secrets JSON parameter will look similar to the following. The keys are the
+reference names, and the values the resolved secrets.
+
+```json
+{
+  "((redis_password))": "some-bosh-generated-password",
+  "((/global/root_ca))": "some-global-value"
+}
+```
+
+If `resolve_manifest_secrets_at_bind` is set to false in the broker, secrets will be empty.
+
+<p class="note"><strong>Note</strong>: We recommend adapter authors to
+find the secrets key by accessing the manifest field that contains the reference
+to the variable.</p>
 
 #### <a id="create-binding-credentials"></a>Credentials for Bindings
 

--- a/operating.html.md.erb
+++ b/operating.html.md.erb
@@ -482,6 +482,45 @@ service_catalog:
           instances: [INSTANCE-NAME] #optional, for co-locating errand
         pre_delete: ERRAND-NAME #optional
 ```
+## <a id="secure-bind-credentials"></a>Accessing Manifest Secrets at Bind Time
+
+A service adapter may need to access secrets embedded in a service instance
+manifest when processing a create binding request. For example, it might need
+credentials with sufficient privileges to add new user to a service and these
+credentials will have been set up in the service instance manifest. ODB will
+pass this manifest to the adapter in the `create-binding` call, but if best
+practice has been followed, the secrets will be represented by BOSH variables
+or literal CredHub references, and so the actual secrets themselves will not be
+present in the manifest.
+
+When the `resolve_manifest_secrets_at_bind` flag is set to true in the ODB
+manifest, ODB will generate a map of manifest variable names and CredHub
+references to secret values for all secrets in the manifest, by querying BOSH
+and its CredHub instance, and will pass this to the adapter `create-binding`
+call.
+
+When `resolve_manifest_secrets_at_bind` is enabled, details for accessing BOSH
+CredHub must also be supplied in then manifest, as shown below:
+
+```
+instance_groups:
+- name: broker
+  ...
+  jobs:
+  - name: broker
+    ...
+    properties:
+      ...
+      resolve_manifest_secrets_at_bind: true
+      bosh_credhub_api:
+        url: https://BOSH-CREDHUB-ADDRESS:8844/
+        root_ca_cert: BOSH-CREDHUB-CA-CERT
+        authentication:
+          uaa:
+            client_credentials:
+              client_id: BOSH-CREDHUB-CLIENT-ID
+              client_secret: BOSH-CREDHUB-CLIENT-SECRET
+```
 
 ## <a id="secure-binding"></a>(Optional) Enable Secure Binding
 


### PR DESCRIPTION
This documentation has been added at the main chunk of an epic called
secure-manifests-spr-18.

[#158766590]

Co-authored-by: Jack Newberry <jnewberry@pivotal.io>