### PR TITLE
ODB secret resolution failures during bind are logged

### DIFF
--- a/adapter-reference.html.md.erb
+++ b/adapter-reference.html.md.erb
@@ -690,12 +690,12 @@ See the following example:
 
 ####<a id="create-binding-secrets"></a>MANIFEST-SECRETS-JSON
 
-If `resolve_manifest_secrets_at_bind` is set to true in the broker,
+If `enable_secure_manifests` is set to true in the broker,
 any secrets in the service instance manifest using references to BOSH generated
 variables or literal CredHub paths are resolved and provided to the adapter in the secrets
 JSON parameter.
 
-If `resolve_manifest_secrets_at_bind` is set to false in the broker, secrets JSON will be empty.
+If `enable_secure_manifests` is set to false in the broker, secrets JSON will be empty.
 
 The following is an example service instance manifest:
 

--- a/operating.html.md.erb
+++ b/operating.html.md.erb
@@ -566,11 +566,17 @@ Replace the placeholder text below with your values for accessing CredHub:
       ```
    
 <br>
-When the `resolve_manifest_secrets_at_bind` flag is set to true,
-ODB generates a map of manifest variable names, and CredHub
-references to secret values for all secrets in the manifest, by querying BOSH
-and its CredHub instance. 
-ODB passes this map to the service adapter's `create-binding` call.
+When the `resolve_manifest_secrets_at_bind` flag is set to true, ODB queries
+BOSH and its CredHub instance and then generates a map of manifest variable
+names and CredHub references to secret values for all secrets in the manifest.
+ODB passes this map to the service adapter's `create-binding` call. For an
+example of the JSON passed in the `create-binding` call, see the [Service
+Adapter Interface Reference
+documentation](./adapter-reference.html#create-binding-secrets). If ODB is
+unable to resolve a particular secret, the broker will log the failure and omit
+it from the passed secrets map. It is the responsibility of the adapter to
+decide what to do about missing secrets based on whether they are required for
+binding creation. ODB will not fail if it cannot resolve a secret.
 
 ## <a id="secure-binding"></a>(Optional) Enable Secure Binding
 

--- a/operating.html.md.erb
+++ b/operating.html.md.erb
@@ -526,7 +526,7 @@ Secrets in the manifest can be:
 If you use BOSH variables or literal CredHub references in your manifest, 
 do the following in the ODB manifest so that the service adapter can access the secrets:
 
-1. Set the `resolve_manifest_secrets_at_bind` flag to true.<br><br>
+1. Set the `enable_secure_manifests` flag to true.<br><br>
 For example:
 
       ```
@@ -538,7 +538,7 @@ For example:
           ...
           properties:
             ...
-            resolve_manifest_secrets_at_bind: true
+            enable_secure_manifests: true
             ...
       ```
 
@@ -554,7 +554,7 @@ Replace the placeholder text below with your values for accessing CredHub:
           ...
           properties:
             ...
-            resolve_manifest_secrets_at_bind: true
+            enable_secure_manifests: true
             bosh_credhub_api:
               url: https://BOSH-CREDHUB-ADDRESS:8844/
               root_ca_cert: BOSH-CREDHUB-CA-CERT
@@ -566,7 +566,7 @@ Replace the placeholder text below with your values for accessing CredHub:
       ```
    
 <br>
-When the `resolve_manifest_secrets_at_bind` flag is set to true, ODB queries
+When the `enable_secure_manifests` flag is set to true, ODB queries
 BOSH and its CredHub instance and then generates a map of manifest variable
 names and CredHub references to secret values for all secrets in the manifest.
 ODB passes this map to the service adapter's `create-binding` call. For an


### PR DESCRIPTION
When ODB cannot resolve a manifest secret during create-binding, it logs
the failure and does not include it in the secrets passed to the service
adapter

[#157430941]

Co-authored-by: Winna Bridgewater <wbridgewater@pivotal.io>