### PR TITLE
Fix broken link to BOSH Teams docs

### DIFF
--- a/operating.html.md.erb
+++ b/operating.html.md.erb
@@ -186,7 +186,7 @@ For an example of how to add this in the manifest, see the line containing
 
 You can use BOSH teams to further control how BOSH operations are available to
 different clients. For more information about using BOSH teams,
-see [Using Teams](https://bosh.io/docs/director-users-uaa-perms.html)
+see [Using Teams](https://bosh.io/docs/director-bosh-teams/)
 in the BOSH documentation.
 
 


### PR DESCRIPTION
Original link https://bosh.io/docs/director-users-uaa-perms.html 404s.
I believe that the new link is https://bosh.io/docs/director-bosh-teams/