### PR TITLE
v0.31.0

### DIFF
--- a/monitor.html.md.erb
+++ b/monitor.html.md.erb
@@ -1,0 +1,156 @@
+---
+title: Monitoring Your On-Demand Broker
+owner: London Services Enablement
+---
+
+This topic explains on-demand broker metrics. See [Logging and Metrics](http://docs.pivotal.io/pivotalcf/loggregator/index.html) for general information about logging and metrics in PCF.
+
+## <a id="metrics"></a>What Are Metrics
+
+Metrics are regularly generated log messages that report measured component states. Metrics are long, single lines of text that contain the following:
+
+```
+  origin:"<BROKER_DEPLOYMENT_NAME>"
+  eventType:ValueMetric
+  timestamp:1560950924586744417
+  deployment:"<BROKER_DEPLOYMENT_NAME>"
+  job:"broker"
+  index:"0"
+  ip:"<SOME_IP>"
+  tags:<
+    key:"source_id"
+    value:"broker"
+  >
+  valueMetric:<
+    name:"/on-demand-broker/<BROKER_DEPLOYMENT_NAME>/total_instances"
+    value:10
+    unit:"count"
+  >
+```
+## <a id="odb-metrics"></a>On-Demand Broker Metrics
+
+The following sections describe the metrics used for monitoring the On-Demand Broker.
+
+### <a id="global-service-instance-count-metrics"></a>Global Service Instance Count
+
+<table>
+   <tr><th colspan="2" style="text-align: center;"><br> /on-demand-broker/&lt;SERVICE_NAME&gt;/total_instances<br><br></th></tr>
+   <tr>
+      <th width="25%">Description</th>
+      <td>
+        <strong>Use</strong>: This is the global total number of instances created by the broker.
+        <br><br>
+        <strong>Origin</strong>: Doppler/Firehose<br>
+        <strong>Type</strong>: count<br>
+      </td>
+   </tr>
+   <tr>
+      <th>Recommended alert thresholds</th>
+      <td>
+        If <a target="_blank" href="operating.html#service-instance-quotas">service instance quotas</a> are configured <br><br>
+        <strong>Warning</strong>: &gt; quota * 0.8 <br>
+        <strong>Critical</strong>: &gt; quota * 0.95
+      </td>
+   </tr>
+   <tr>
+      <th>Recommended response</th>
+      <td>
+        Delete any unused service instances, or increase the global service instance limit.
+      </td>
+   </tr>
+</table>
+
+### <a id="plan-service-instance-count-metrics"></a>Service Instance Count Per Plan
+
+<table>
+   <tr><th colspan="2" style="text-align: center;"><br> /on-demand-broker/&lt;SERVICE_NAME&gt;/&lt;PLAN_NAME&gt;/total_instances<br><br></th></tr>
+   <tr>
+      <th width="25%">Description</th>
+      <td>
+        <strong>Use</strong>: This is the total number of instances created by the broker for a given plan.
+        <br><br>
+        <strong>Origin</strong>: Doppler/Firehose<br>
+        <strong>Type</strong>: count<br>
+      </td>
+   </tr>
+   <tr>
+      <th>Recommended alert thresholds</th>
+      <td>
+        If <a target="_blank" href="operating.html#service-instance-quotas">service instance quotas</a> are configured<br><br>
+        <strong>Warning</strong>: &gt; quota * 0.8 <br>
+        <strong>Critical</strong>: &gt; quota * 0.95
+      </td>
+   </tr>
+   <tr>
+      <th>Recommended response</th>
+      <td>
+        Delete any unused service instances, select a different plan, or increase the service instance limit for the given plan.
+      </td>
+   </tr>
+</table>
+
+### <a id="global-resource-quota-metrics"></a>Global Resource Quota
+
+<table>
+   <tr><th colspan="2" style="text-align: center;">
+     <br> /on-demand-broker/&lt;SERVICE_NAME&gt;/&lt;RESOURCE_TYPE&gt;/used<br>
+     <br> /on-demand-broker/&lt;SERVICE_NAME&gt;/&lt;RESOURCE_TYPE&gt;/remaining<br><br>
+   </th></tr>
+   <tr>
+      <th width="25%">Description</th>
+      <td>
+        <strong>Use</strong>: These two metrics combine to give a picture of global resource quota usage for instances created by the broker.
+        <br><br>
+        <strong>Origin</strong>: Doppler/Firehose<br>
+        <strong>Type</strong>: count<br>
+      </td>
+   </tr>
+   <tr>
+      <th>Recommended alert thresholds</th>
+      <td>
+        If <a target="_blank" href="operating.html#service-resource-quotas">service instance resource quotas</a> are configured <br><br>
+        <strong>Warning</strong>: &gt; quota * 0.8 <br>
+        <strong>Critical</strong>: &gt; quota * 0.95
+      </td>
+   </tr>
+   <tr>
+      <th>Recommended response</th>
+      <td>
+        Delete any unused service instances, or increase the global quota for this resource.
+      </td>
+   </tr>
+</table>
+
+### <a id="plan-service-instance-count-metrics"></a>Resource Quota Per Plan
+
+<table>
+   <tr>
+     <th colspan="2" style="text-align: center;">
+       <br> /on-demand-broker/&lt;SERVICE_NAME&gt;/&lt;PLAN_NAME&gt;/&lt;RESOURCE_TYPE&gt;/used<br>
+       <br> /on-demand-broker/&lt;SERVICE_NAME&gt;/&lt;PLAN_NAME&gt;/&lt;RESOURCE_TYPE&gt;/remaining<br><br>
+     </th>
+  </tr>
+   <tr>
+      <th width="25%">Description</th>
+      <td>
+        <strong>Use</strong>: These two metrics combine to give a picture of resource quota usage for instances created by the broker for a given plan.
+        <br><br>
+        <strong>Origin</strong>: Doppler/Firehose<br>
+        <strong>Type</strong>: count<br>
+      </td>
+   </tr>
+   <tr>
+      <th>Recommended alert thresholds</th>
+      <td>
+        If <a target="_blank" href="operating.html#service-resource-quotas">service instance resource quotas</a> are configured <br><br>
+        <strong>Warning</strong>: &gt; quota * 0.8 <br>
+        <strong>Critical</strong>: &gt; quota * 0.95
+      </td>
+   </tr>
+   <tr>
+      <th>Recommended response</th>
+      <td>
+        Delete any unused service instances, select a different plan, or increase the quota for this resource for the given plan.
+      </td>
+   </tr>
+</table>

--- a/operating.html.md.erb
+++ b/operating.html.md.erb
@@ -654,9 +654,11 @@ service_catalog:
     # the maximum number of service instances across all plans:
     service_instance_limit: INSTANCE-LIMIT
     # optional - resource usage limits, determined by the 'cost' of each service instance plan:
-    resource_limits:
-      ips: RESOURCE-LIMIT
-      memory: RESOURCE-LIMIT
+    resources:
+      ips:
+        limit: RESOURCE-LIMIT
+      memory:
+        limit: RESOURCE-LIMIT
   # optional - applied to every plan.
   maintenance_info:
     # keys under public are visible in service catalog
@@ -691,16 +693,18 @@ service_catalog:
           - amount:
               CURRENCY-CODE-STRING: CURRENCY-AMOUNT-FLOAT
             unit: FREQUENCY-OF-COST
-      # optional – the 'cost' of each instance in terms of resource quotas:
-      resource_costs:
-        memory: AMOUNT-OF-RESOURCE-IN-THIS-PLAN
       # optional:
       quotas:
         # the maximum number of service instances for this plan:
         service_instance_limit: INSTANCE-LIMIT
         # optional - resource usage limits for this plan:
-        resource_limits:
-          memory: RESOURCE-LIMIT
+        resources:
+          # Arbitrary hash of resource types:
+          memory:
+            # optional - overwrites global limit for this resource type
+            limit: RESOURCE-LIMIT
+            # optional – the 'cost' of each instance in terms of resource type:
+            cost: RESOURCE-COST
       # resource mapping for the instance groups defined by the service author:
       instance_groups:
         - name: SERVICE-AUTHOR-PROVIDED-INSTANCE-GROUP-NAME
@@ -1061,23 +1065,30 @@ For a more detailed manifest snippet, see the [Starter Snippet for the Service C
 
 ## <a id="service-resource-quotas"></a>(Optional) Set Resource Quotas
 
-Set resource quotas to limit resources, such as memory or disk, more effectively
-when combining plans that consume different amounts of resources.
-You can set these quotas for service resources:
+Sometimes, only relying on the number of service instances when defining quotas is not enough.
+You may have a limitation not only on the number of instances but also on phisycal resources like
+memory, persistent disk size or ip addresses in the network. To determine how much of each resource a
+particular plan can use, you may want to define resource quotas.
 
-- **Global resource quotas** -- limit how much of a certain resource is consumed
-across all plans. ODB allows new instances to be created until their total
-resources reach the global quota.
-- **Plan resource quotas** -- limit how much of a certain resource is consumed by a
-specific plan.
+A resource quota is defined by an arbitrary resource type with two associated keys: limit and cost.
 
-<p class="note"><strong>Note</strong>: These limits do not include orphaned deployments.
-  See <a href="./troubleshooting-bosh.html#listing-orphans">List Orphan Deployments</a>
-   and <a href="./management.html#orphan-deployments">Delete Orphaned Deployments</a>
- for more information.</p>
+You can set resource quotas in two levels:
 
-When creating a service instance, ODB checks the global resource limit.
-If this limit has not been reached, ODB checks the plan resource limit.
+- **Global resource quota** -- limit how much of a certain resource is
+available to be consumed across all plans. ODB allows new instances to be
+created until the sum of resources consumed reach the global quota. Resource
+costs cannot be defined at the global level
+- **Plan resource quota** -- limit how much of a certain resource is
+avaialable and/or consumed by a specific plan.
+
+Resource quotas are enforced first at the global level and then at plan level,
+by checking the limits for each resource type.
+
+<p class="note"><strong>Note</strong>: When calculating the amount of resources used,
+ODB will not take orphan deployments into consideration.  See <a
+href="./troubleshooting-bosh.html#listing-orphans">List Orphan Deployments</a>
+and <a href="./management.html#orphan-deployments">Delete Orphaned
+Deployments</a> for more information.</p>
 
 ### Procedure for Setting Service Resource Quotas
 
@@ -1088,14 +1099,17 @@ following.
 
     ```
     quotas:
-      resource_limits:
-        RESOURCE-NAME: RESOURCE-LIMIT
+      resources:
+        RESOURCE-NAME:
+          limit: RESOURCE-LIMIT
+          cost: RESOURCE-COST # if at plan level
     ```
   Where:<br>
   <ul>
     <li><code>RESOURCE-NAME</code> is a string defining the resource you want to limit.</li>
     <li><code>RESOURCE-LIMIT</code> is a value for the maximum allowed for each resource.</li>
-  </ul>
+    <li><code>RESOURCE-COST</code> is a value of how much a service instance of
+    the plan will consume for that resource.</li> </ul>
 For example:
     - **For global quotas** add `global_quotas` in the service catalog, as in
     this example:
@@ -1104,13 +1118,12 @@ For example:
         service_catalog:
           ...
           global_quotas:
-            resource_limits:
-              ips: 50
-              memory: 150
+            resources:
+              ips: { limit: 50 }
+              memory: { limit: 150 }
         ```
         <br>
-    - **For plan quotas** add `quotas` in the plans you want to limit, as in
-    this example:
+    - **For plan quotas** add `quotas` in the plans you want to enforce quotas. For example:
 
         ```yaml
         service_catalog:
@@ -1118,36 +1131,13 @@ For example:
           plans:
             - name: my-plan
               quotas:
-                resource_limits:
-                  memory: 25
+                resources:
+                  ips:
+                    cost: 2 # each service will consume 2, up to 50 from the global resource limit
+                  memory:
+                    limit: 25 # maximum limit of "memory" to be consumed by this plan
+                    cost: 5 # each service instance will consume 5, up to 25 of plan resource limit
         ```
-
-1. Add `resource_costs` in each plan to define the amount of resources your plan
-allocates to each service instance. The key is string-matched against keys in
-the global- and plan-level resource quotas. See the example below.
-
-    ```yaml
-    resource_costs:
-      RESOURCE-NAME: AMOUNT-OF-RESOURCE
-    ```
-    Where:<br>
-    - `RESOURCE-NAME` is a string defining the resource you want to limit.
-    - `AMOUNT-OF-RESOURCE` is the amount of the resource allocated to each
-    service instance of this plan.
-
-
-
-    For example:
-
-    ```yaml
-    service_catalog:
-      ...
-      plans:
-        - name: my-plan
-          resource_costs:
-            memory: 5
-    ```
-
 
 For a more detailed manifest snippet, see the [Starter Snippet for the Service Catalog and Plans](#starter-snippet) above.
 

--- a/operating.html.md.erb
+++ b/operating.html.md.erb
@@ -1066,7 +1066,7 @@ For a more detailed manifest snippet, see the [Starter Snippet for the Service C
 ## <a id="service-resource-quotas"></a>(Optional) Set Resource Quotas
 
 Sometimes, only relying on the number of service instances when defining quotas is not enough.
-You may have a limitation not only on the number of instances but also on phisycal resources like
+You may have a limitation not only on the number of instances but also on physical resources like
 memory, persistent disk size or ip addresses in the network. To determine how much of each resource a
 particular plan can use, you may want to define resource quotas.
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -10,7 +10,7 @@ owner: London Services Enablement
 
 ### Features
 
-New feature in this release:
+New features in this release:
 
 **Indicator Protocol**
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -12,11 +12,14 @@ owner: London Services Enablement
 
 New feature in this release:
 
-*
+**Indicator Protocol**
 
-*
+* The broker will now publish the number of service instances created per service and per plan to the PCF Healthwatch service. For that, we added [indicators](https://github.com/pivotal/monitoring-indicator-protocol) to the [on demand broker release](https://github.com/pivotal-cf/on-demand-service-broker-release/blob/master/jobs/broker/templates/indicators.yml.erb). For more information about Healthwatch, see [Pivotal Cloud Foundry Healthwatch](https://docs.pivotal.io/pcf-healthwatch/index.html).
 
-*
+**Resource quotas**
+
+* Resource quotas have a new format. See [Setting Resource Quotas](operating.html#service-resource-quotas) for instructions. The previous format is still supported and will be removed in a future release.
+* Global and Plan resource quotas metrics are now emitted by the broker. For details on these metrics, see [Monitoring Your On-Demand Broker](monitor.html)
 
 ### Known Issues
 


### PR DESCRIPTION
There's a new page on our docs that need to be included in the navigation menu: monitor.html. We think the best place for it is in the Operator guide - just before Troubleshooting On-Demand Services. Can you please update the pivotal-cf/docs-book-odb accordingly?
