### PR TITLE
Do not refer to OpsManager tile documentation for ODB lifecycle errands

### DIFF
--- a/concepts.html.md.erb
+++ b/concepts.html.md.erb
@@ -98,7 +98,7 @@ If a user runs the `cf create-service` command with post-deploy errands configur
 for the deployment, ODB does not report success to Cloud Foundry until the deployment
 is created, or updated, and all post-deploy errands complete.
 For more information, see
-[Post-Deploy Errands](https://docs.pivotal.io/tiledev/tile-errands.html#post-deploy).
+[lifecycle errands](operating.html#lifecycle-errands).
 
 The sequence diagram below shows the workflow for creating or updating a service
 instance when post-deploy errands are configured.
@@ -220,7 +220,7 @@ If a user runs the `cf delete-service` command with pre-delete errands configure
 for the deployment, ODB does not report success to Cloud Foundry until all
 pre-delete errands complete and the deployment is deleted.
 For more information, see
-[Pre-Delete Errands](https://docs.pivotal.io/tiledev/tile-errands.html#pre-delete).
+[lifecycle errands](operating.html#lifecycle-errands).
 
 The sequence diagram below shows the workflow for deleting service instances with
 pre-delete errands configured.

--- a/creating.html.md.erb
+++ b/creating.html.md.erb
@@ -85,7 +85,8 @@ part of service instance deployment.
 ODB uses these errands to manage an instance lifecycle.
 A deployment is only considered successful if the deployment and all
 lifecycle errands complete successfully.
-For more information about errands, see [Errands](https://docs.pivotal.io/tiledev/tile-errands.html).
+For more information about errands, see
+[lifecycle errands](operating.html#lifecycle-errands).
 
 ODB supports the following service instance lifecycle errands:
 

--- a/operating.html.md.erb
+++ b/operating.html.md.erb
@@ -1348,11 +1348,9 @@ ODB supports the following lifecycle errands:
 
 - `post_deploy` runs after creating or updating a service instance. An example use case is
   running a health check to ensure the service instance is functioning.<br>
-  For more information about these errands, see [Post-Deploy Errands](https://docs.pivotal.io/tiledev/tile-errands.html#post-deploy).
   For more information about the workflow, see [Create or Update Service Instance with Post-Deploy Errands](./concepts.html#post-deploy).<br><br>
 - `pre_delete` runs before the deletion of a service instance.
-  An example use case is cleaning up data before a service shutdown. For more
-  information about these errands, see [Pre-Delete Errands](https://docs.pivotal.io/tiledev/tile-errands.html#pre-delete).
+  An example use case is cleaning up data before a service shutdown. 
   For more information about the workflow, see [Delete a Service Instance with Pre-Delete Errands](./concepts.html#pre-delete).
 
 ### <a id="enable-errands"></a> Enable Service Instance Lifecycle Errands


### PR DESCRIPTION
Issue: Sections on our documentation point to OpsManager errands. This caused confusion when Rabbit explored whether ODB had lifecycle errands, and they thought ODB didn't because our docs pointed to OpsManager.

[#167393549]