### PR TITLE
Clarify how to use Secure Manifest feature

### DIFF
--- a/operating.html.md.erb
+++ b/operating.html.md.erb
@@ -739,9 +739,15 @@ The broker also accepts only the following cipher suites:
 - TLS\_ECDHE\_RSA\_WITH\_AES\_128\_GCM\_SHA256
 - TLS\_ECDHE\_RSA\_WITH\_AES\_256\_GCM\_SHA384
 
-## <a id="secure-bind-credentials"></a>(Optional) Access Manifest Secrets at Bind Time
+## <a id="secure-manifest"></a>(Optional) Manifest Secrets Stored in CredHub
 
 <p class="note alert"><strong>Note:</strong> This feature does not work if you have configured <code>use_stdin</code> to be false.</p>
+
+To avoid writing secrets in plaintext in the manifest, you can use ODB-managed
+secrets to store secrets on BOSH CredHub.
+When using ODB-managed secrets, the service adapter generates secrets and uses
+ODB as a proxy to the BOSH CredHub config server. For more information about how
+to store manifest secrets in BOSH CredHub see [(Optional) Store Secrets on BOSH CredHub](./service-adapter.html#storing-secrets).
 
 A service adapter might need to access secrets embedded in a service instance
 manifest when processing a create binding request.

--- a/service-adapter.html.md.erb
+++ b/service-adapter.html.md.erb
@@ -347,6 +347,12 @@ BOSH CredHub name.
 
 1. Deploys the updated manifest.
 
+<p class="note"><strong>Note: </strong>
+  to use this feature, the <code>enable_secure_manifests</code> flag must be set to <code>true</code>
+  and ODB must be configured with the credentials to access BOSH CredHub. For information
+  on how to do this see <a href="./operating.html#secure-manifest">(Optional) Manifest Secrets Stored in CredHub</a>.
+</p>
+
 The following sections provide information about how to use ODB-managed secrets to store,
 persist, and modify secrets in BOSH CredHub:
 


### PR DESCRIPTION
This feature was introduced in v0.23 so ideally we would back-port the change to all versions in between. However there was significant edit in v0.28, so it might need quite a lot of work to back-port to versions before v0.28. Since we don't have a lot of new development on those older versions, it might be sensible to back-port only to v0.28.