### PR TITLE
Add release notes for v0.33.1

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -4,36 +4,33 @@ owner: London Services Enablement
 ---
 <strong><%= modified_date %></strong>
 
-## <a id="0-34-0"></a>v0.34.0
+## <a id="0-33-1"></a>v0.33.1
 
 **Release Date: MMMM DD, 2019**
-
 
 ### Features
 
 New features and changes in this release:
 
-
+* Bumps Golang to v1.12.10
 
 ### Resolved Issue
 
 This release has the following fix:
 
-
+* Changes BOSH API call `/deployments` to `/deployments?exclude_configs=true` as this is faster.
 
 ### Known Issues
 
 There are no known issues for this release.
 
-
-
 ### Compatibility
 
 This on-demand service broker release has the following dependency:
 
-| Dependency  | Version  |
+ | Dependency  | Version  |
 |---|---|
-|   |  |
+|  Golang | 1.12.10 |
 
 
 ## <a id="view"></a> View Release Notes for Another Version


### PR DESCRIPTION
We couldn't find a v0.33.x branch. Could you please add this documentation to the 0.33.x branch of our docs? 

v0.33.1 will be released soon.

Thanks!

[#168948769]