### PR TITLE
Update release notes for v0.41.1

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -6,13 +6,16 @@ owner: London Services Enablement
 
 <%= partial vars.path_to_partials + "/upgrade-planner" %>
 
-## <a id="0-41-0"></a> v0.41.0
+## <a id="0-41-0"></a> v0.41.1
 
-**Release Date: MMMM DD, 2020**
+**Release Date: April 14, 2021**
 
 ### Features
 
 New features and changes in this release:
+* Enables option to skip SSL validation when interacting with UAA to create clients. The value of broker's `disable_ssl_cert_verification` property can be used for this purpose.
+* Updated to Go 1.16.3.
+* Other dependency updates.
 
 ### Known Issues.
 
@@ -33,7 +36,7 @@ This release has the following dependency:
 
   <tr>
     <td>golang</td>
-    <td>x.x.x</td>
+    <td>1.16.3</td>
   </tr>
 
 </table>


### PR DESCRIPTION
We made an accidental release 0.40.0 which will not be available in PivNet and we want to document only 0.41.1

Which other branches should this be merged with (if any)?
