### PR TITLE
Updates references of pivotal.io to bosh.io

### DIFF
--- a/about.html.md.erb
+++ b/about.html.md.erb
@@ -27,7 +27,7 @@ which developers access with `cf marketplace` or through Apps Manager.
 
 ### <%= vars.ops_manager %> Tiles
 
-Operators find services on [<%= vars.product_network %>](https://network.pivotal.io/)
+Operators find services on [<%= vars.product_network %>](https://network.tanzu.vmware.com/)
 and install and configure them through a tile interface in the <%= vars.ops_manager %> **Installation Dashboard**
 to make them available to developers.
 Installing a service tile creates a service broker, registers it with the Cloud Controller,

--- a/getting-started.html.md.erb
+++ b/getting-started.html.md.erb
@@ -96,7 +96,7 @@ To set up the Kafka example service adapter, do the following:
 To set up <%= vars.product_abbr %>, do the following:
 
 1. Download the on-demand service broker from <%= vars.product_network %>. To download,
-see [<%= vars.product_full %>](https://network.pivotal.io/products/on-demand-services-sdk/).
+see [<%= vars.product_full %>](https://bosh.io/releases/github.com/pivotal-cf/on-demand-service-broker-release).
 
 1. Upload the `on-demand-service-broker` release.
 

--- a/operating.html.md.erb
+++ b/operating.html.md.erb
@@ -354,7 +354,7 @@ uaa:
 
 Upload the following releases to your BOSH Director:
 
-* **On Demand Service Broker (<%= vars.product_abbr %>)**---Download <%= vars.product_abbr %> from [<%= vars.product_network %>](https://network.pivotal.io/products/on-demand-services-sdk/).
+* **On Demand Service Broker (<%= vars.product_abbr %>)**---Download <%= vars.product_abbr %> from [<%= vars.product_network %>](https://bosh.io/releases/github.com/pivotal-cf/on-demand-service-broker-release).
 * **Your service adapter**---Get the service adapter from the release author.
 * **Your service release**---Get the service release from the release author.
 * **BOSH Process Manager (bpm) release**---Get the bpm release from the location listed in [BOSH releases](https://bosh.io/releases/github.com/cloudfoundry-incubator/bpm-release?all=1) in the BOSH documentation. You might not need to do this if the bpm release is already uploaded.
@@ -1150,7 +1150,7 @@ with the Service Metrics SDK.
 To do this, you must include the Loggregator release.
 For more information, see [Loggregator](https://github.com/cloudfoundry/loggregator) in GitHub.
 
-To download the Service Metrics SDK, see [<%= vars.product_network %>](https://network.pivotal.io/products/service-metrics-sdk/).
+To download the Service Metrics Release, see [<%= vars.product_network %>](https://bosh.io/releases/github.com/cloudfoundry/service-metrics-release).
 
 Add the following jobs to the broker instance group:
 

--- a/tile.html.md.erb
+++ b/tile.html.md.erb
@@ -14,7 +14,7 @@ in GitHub.
 To build an on-demand tile you need the following releases:
 
 - **On Demand Service Broker (<%= vars.product_abbr %>)**---Download <%= vars.product_abbr %> from
-[<%= vars.product_network %>](https://network.pivotal.io/products/on-demand-services-sdk/).
+[<%= vars.product_network %>](https://bosh.io/releases/github.com/pivotal-cf/on-demand-service-broker-release).
 - **Your service adapter**---Get this from the service author.
 - **Your service release**---Get this from the release author.
 

--- a/upgrades.html.md.erb
+++ b/upgrades.html.md.erb
@@ -13,7 +13,7 @@ to <%= vars.ops_manager %> operators and BOSH operators.
 To upgrade the broker, do the following:
 
 1. Download a new version of the on-demand service broker BOSH release from
-[<%= vars.product_network %>](https://network.pivotal.io/products/on-demand-services-sdk/).
+[<%= vars.product_network %>](https://bosh.io/releases/github.com/pivotal-cf/on-demand-service-broker-release).
 
 1. Upload the release to the BOSH Director by running:
 


### PR DESCRIPTION
[#183998490](https://www.pivotaltracker.com/story/show/183998490)

Which other branches should this be merged with (if any)?

- Updated the path from network.pivotal.io to network.tanzu.vmware.com
- Updated the on demand services broker location from the old network.pivotal.io to bosh.io
- Service Metrics Release was also moved over to bosh.io a couple of years ago.
