### PR TITLE
Relabel links to bosh.io-hosted releases

### DIFF
--- a/config/template_variables.yml
+++ b/config/template_variables.yml
@@ -14,6 +14,7 @@ template_variables:
   support_call_to_action: <a href="http://support.pivotal.io" target="_blank">Need Support?</a>
   support_url: http://support.pivotal.io
   product_network: VMware Tanzu Network
+  oss_releases: BOSH.io Releases
 
   path_to_partials: /svc-sdk/odb/partials
 

--- a/getting-started.html.md.erb
+++ b/getting-started.html.md.erb
@@ -95,8 +95,8 @@ To set up the Kafka example service adapter, do the following:
 
 To set up <%= vars.product_abbr %>, do the following:
 
-1. Download the on-demand service broker from <%= vars.product_network %>. To download,
-see [<%= vars.product_full %>](https://bosh.io/releases/github.com/pivotal-cf/on-demand-service-broker-release).
+1. Download the on-demand service broker from <%= vars.oss_releases %>. To download,
+see [on-demand-service-broker](https://bosh.io/releases/github.com/pivotal-cf/on-demand-service-broker-release).
 
 1. Upload the `on-demand-service-broker` release.
 

--- a/operating.html.md.erb
+++ b/operating.html.md.erb
@@ -354,10 +354,10 @@ uaa:
 
 Upload the following releases to your BOSH Director:
 
-* **On Demand Service Broker (<%= vars.product_abbr %>)**---Download <%= vars.product_abbr %> from [<%= vars.product_network %>](https://bosh.io/releases/github.com/pivotal-cf/on-demand-service-broker-release).
+* **On Demand Service Broker (<%= vars.product_abbr %>)**---Download <%= vars.product_abbr %> from [<%= vars.oss_releases %>](https://bosh.io/releases/github.com/pivotal-cf/on-demand-service-broker-release).
 * **Your service adapter**---Get the service adapter from the release author.
 * **Your service release**---Get the service release from the release author.
-* **BOSH Process Manager (bpm) release**---Get the bpm release from the location listed in [BOSH releases](https://bosh.io/releases/github.com/cloudfoundry-incubator/bpm-release?all=1) in the BOSH documentation. You might not need to do this if the bpm release is already uploaded.
+* **BOSH Process Manager (bpm) release**---Get the bpm release from [<%= vars.oss_releases %>](https://bosh.io/releases/github.com/cloudfoundry-incubator/bpm-release?all=1). You might not need to do this if the bpm release is already uploaded.
 
 To upload a release to your BOSH Director, run:
 
@@ -1150,7 +1150,7 @@ with the Service Metrics SDK.
 To do this, you must include the Loggregator release.
 For more information, see [Loggregator](https://github.com/cloudfoundry/loggregator) in GitHub.
 
-To download the Service Metrics Release, see [<%= vars.product_network %>](https://bosh.io/releases/github.com/cloudfoundry/service-metrics-release).
+To download the Service Metrics Release, see [<%= vars.oss_releases %>](https://bosh.io/releases/github.com/cloudfoundry/service-metrics-release).
 
 Add the following jobs to the broker instance group:
 

--- a/tile.html.md.erb
+++ b/tile.html.md.erb
@@ -14,7 +14,7 @@ in GitHub.
 To build an on-demand tile you need the following releases:
 
 - **On Demand Service Broker (<%= vars.product_abbr %>)**---Download <%= vars.product_abbr %> from
-[<%= vars.product_network %>](https://bosh.io/releases/github.com/pivotal-cf/on-demand-service-broker-release).
+[<%= vars.oss_releases %>](https://bosh.io/releases/github.com/pivotal-cf/on-demand-service-broker-release).
 - **Your service adapter**---Get this from the service author.
 - **Your service release**---Get this from the release author.
 

--- a/upgrades.html.md.erb
+++ b/upgrades.html.md.erb
@@ -13,7 +13,7 @@ to <%= vars.ops_manager %> operators and BOSH operators.
 To upgrade the broker, do the following:
 
 1. Download a new version of the on-demand service broker BOSH release from
-[<%= vars.product_network %>](https://bosh.io/releases/github.com/pivotal-cf/on-demand-service-broker-release).
+[<%= vars.oss_releases %>](https://bosh.io/releases/github.com/pivotal-cf/on-demand-service-broker-release).
 
 1. Upload the release to the BOSH Director by running:
 


### PR DESCRIPTION
- Introduce a template variable `oss_releases` "Bosh.io Releases" as the open-source counterpart to existing template variable `product_network` "VMware Tanzu Network"
- Rework new ODB bosh.io links to use oss_releases not product_network as their link text.
- (Also backported oss_releases to existing bosh.io reference for service-metrics-release.)

[#183998490](https://www.pivotaltracker.com/story/show/183998490)

Authored-by: Kim Bassett <kbassett@vmware.com>

Which other branches should this be merged with (if any)?
A: None. This is effective as of the current v0.42.7 release and all subsequent releases.
